### PR TITLE
Restructure main/provider path and add plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-CSI-NFS
+CSI-NFS [![Build Status](http://travis-ci.org/thecodeteam/csi-nfs.svg?branch=master)](https://travis-ci.org/thecodeteam/csi-nfs)
 -------
 
-CSI-NFS is an implementation of a
-[CSI](https://github.com/container-storage-interface) plugin for NFS volumes.
+CSI-NFS is a Container Storage Interface
+([CSI](https://github.com/container-storage-interface/spec)) plug-in
+that provides network filesystem (NFS) support.
 
-It is structured such that it can be compiled into a standalone golang binary
-that can be executed to meet the requirements of a CSI plugin. Furthermore, the
-core NFS logic is separated into a `nfs` go package that can be imported for use
-by other programs.
+This project may be compiled as a stand-alone binary using Golang that,
+when run, provides a valid CSI endpoint. This project can also be
+vendored or built as a Golang plug-in in order to extend the functionality
+of other programs.
 
 Installation
 -------------
@@ -90,21 +91,22 @@ Here are some sample commands:
 
 ```sh
 $ csc gets
-0.1.0
-$ csc getp
+0.0.0
+$ csc getp -version 0.0.0
 csi-nfs	0.1.0
-$ csc cget
+$ csc cget -version 0.0.0
 LIST_VOLUMES
 $ showmount -e 192.168.75.2
 Exports list on 192.168.75.2:
 	/data                             192.168.75.1
-$ csc mnt -targetPath /tmp/mnt -mode 1 host=192.168.75.2 export=/data
-$ ls -al /tmp/mnt
+$ mkdir /mnt/test
+$ csc mnt -version 0.0.0 -targetPath /mnt/test -mode 1 host=192.168.75.2 export=/data
+$ ls -al /mnt/test
 total 1
 drwxr-xr-x   2 root  wheel    18 Jul 22 20:25 .
 drwxrwxrwt  85 root  wheel  2890 Aug 17 15:32 ..
 -rw-r--r--   1 root  wheel     0 Jul 22 20:25 test
-$ csc umount -targetPath /tmp/mnt host=192.168.75.2 export=/data
+$ csc umount -version 0.0.0 -targetPath /mnt/test host=192.168.75.2 export=/data
 $ ls -al /tmp/mnt
 total 0
 drwxr-xr-x   2 travis  wheel    68 Aug 16 15:01 .

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,19 @@
+// +build linux,plugin
+
+package main
+
+import "C"
+
+import (
+	"github.com/thecodeteam/csi-nfs/provider"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//                              Go Plug-in                                    //
+////////////////////////////////////////////////////////////////////////////////
+
+// ServiceProviders is an exported symbol that provides a host program
+// with a map of the service provider names and constructors.
+var ServiceProviders = map[string]func() interface{}{
+	name: func() interface{} { return provider.New() },
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"sync"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/thecodeteam/gocsi"
 	"github.com/thecodeteam/gocsi/csi"
 	"github.com/thecodeteam/goioc"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
 	"github.com/thecodeteam/csi-nfs/services"
@@ -23,25 +23,80 @@ const (
 )
 
 var (
-	errServerStarted = errors.New(
-		services.SpName + ": the server has been started")
-	errServerStopped = errors.New(
-		services.SpName + ": the server has been stopped")
+	errServerStopped = errors.New("server stopped")
+	errServerStarted = errors.New("server started")
 )
 
+// ServiceProvider is a gRPC endpoint that provides the CSI
+// services: Controller, Identity, Node.
+type ServiceProvider interface {
+
+	// Serve accepts incoming connections on the listener lis, creating
+	// a new ServerTransport and service goroutine for each. The service
+	// goroutine read gRPC requests and then call the registered handlers
+	// to reply to them. Serve returns when lis.Accept fails with fatal
+	// errors.  lis will be closed when this method returns.
+	// Serve always returns non-nil error.
+	Serve(ctx context.Context, lis net.Listener) error
+
+	// Stop stops the gRPC server. It immediately closes all open
+	// connections and listeners.
+	// It cancels all active RPCs on the server side and the corresponding
+	// pending RPCs on the client side will get notified by connection
+	// errors.
+	Stop(ctx context.Context)
+
+	// GracefulStop stops the gRPC server gracefully. It stops the server
+	// from accepting new connections and RPCs and blocks until all the
+	// pending RPCs are finished.
+	GracefulStop(ctx context.Context)
+}
+
 func init() {
-	goioc.Register(services.SpName, newProvider)
+	goioc.Register(services.Name, func() interface{} { return &provider{} })
+}
+
+// New returns a new service provider.
+func New(
+	opts []grpc.ServerOption,
+	interceptors []grpc.UnaryServerInterceptor) ServiceProvider {
+
+	return &provider{interceptors: interceptors, serverOpts: opts}
 }
 
 type provider struct {
 	sync.Mutex
-	server *grpc.Server
-	closed bool
-	plugin *services.StoragePlugin
+	server       *grpc.Server
+	closed       bool
+	service      services.Service
+	interceptors []grpc.UnaryServerInterceptor
+	serverOpts   []grpc.ServerOption
 }
 
-func newProvider() interface{} {
-	return &provider{}
+// config is an interface that matches a possible config object that
+// could possibly be pulled out of the context given to the provider's
+// Serve function
+type config interface {
+	GetString(key string) string
+}
+
+func (p *provider) newGrpcServer() *grpc.Server {
+
+	var interceptors []grpc.UnaryServerInterceptor
+	if len(p.interceptors) > 0 {
+		interceptors = append(interceptors, p.interceptors...)
+	}
+
+	iopt := gocsi.ChainUnaryServer(interceptors...)
+
+	var serverOpts []grpc.ServerOption
+	if len(p.serverOpts) > 0 {
+		serverOpts = append(serverOpts, p.serverOpts...)
+	}
+
+	serverOpts = append(serverOpts, grpc.UnaryInterceptor(iopt))
+
+	return grpc.NewServer(serverOpts...)
 }
 
 // Serve accepts incoming connections on the listener lis, creating
@@ -51,7 +106,6 @@ func newProvider() interface{} {
 // errors.  lis will be closed when this method returns.
 // Serve always returns non-nil error.
 func (p *provider) Serve(ctx context.Context, li net.Listener) error {
-	log.WithField("name", services.SpName).Info(".Serve")
 	if err := func() error {
 		p.Lock()
 		defer p.Unlock()
@@ -61,23 +115,16 @@ func (p *provider) Serve(ctx context.Context, li net.Listener) error {
 		if p.server != nil {
 			return errServerStarted
 		}
-		p.server = grpc.NewServer(
-			grpc.UnaryInterceptor(gocsi.ChainUnaryServer(
-				gocsi.ServerRequestIDInjector,
-				gocsi.NewServerRequestLogger(os.Stdout, os.Stderr),
-				gocsi.NewServerResponseLogger(os.Stdout, os.Stderr),
-				gocsi.NewServerRequestVersionValidator(services.CSIVersions),
-				gocsi.ServerRequestValidator)))
+		p.server = p.newGrpcServer()
 		return nil
 	}(); err != nil {
 		return errServerStarted
 	}
 
-	p.plugin = &services.StoragePlugin{}
-	p.plugin.Init()
+	p.service = services.New()
 
 	// Always host the Identity Service
-	csi.RegisterIdentityServer(p.server, p.plugin)
+	csi.RegisterIdentityServer(p.server, p.service)
 
 	_, nodeSvc := os.LookupEnv(nodeEnvVar)
 	_, ctrlSvc := os.LookupEnv(ctlrEnvVar)
@@ -91,19 +138,24 @@ func (p *provider) Serve(ctx context.Context, li net.Listener) error {
 
 	switch {
 	case nodeSvc:
-		csi.RegisterNodeServer(p.server, p.plugin)
+		csi.RegisterNodeServer(p.server, p.service)
 		log.Debug("Added Node Service")
 	case ctrlSvc:
-		csi.RegisterControllerServer(p.server, p.plugin)
+		csi.RegisterControllerServer(p.server, p.service)
 		log.Debug("Added Controller Service")
 	default:
-		csi.RegisterControllerServer(p.server, p.plugin)
+		csi.RegisterControllerServer(p.server, p.service)
 		log.Debug("Added Controller Service")
-		csi.RegisterNodeServer(p.server, p.plugin)
+		csi.RegisterNodeServer(p.server, p.service)
 		log.Debug("Added Node Service")
 	}
 
-	// start the grpc server
+	// Start the grpc server
+	log.WithFields(map[string]interface{}{
+		"service": services.Name,
+		"address": fmt.Sprintf(
+			"%s://%s", li.Addr().Network(), li.Addr().String()),
+	}).Info("serving")
 	return p.server.Serve(li)
 }
 
@@ -119,9 +171,9 @@ func (p *provider) Stop(ctx context.Context) {
 
 	p.Lock()
 	defer p.Unlock()
-	log.WithField("name", services.SpName).Info(".Stop")
 	p.server.Stop()
 	p.closed = true
+	log.WithField("service", services.Name).Info("stopped")
 }
 
 // GracefulStop stops the gRPC server gracefully. It stops the server
@@ -134,7 +186,7 @@ func (p *provider) GracefulStop(ctx context.Context) {
 
 	p.Lock()
 	defer p.Unlock()
-	log.WithField("name", services.SpName).Info(".GracefulStop")
 	p.server.GracefulStop()
 	p.closed = true
+	log.WithField("service", services.Name).Info("shutdown")
 }

--- a/services/controller.go
+++ b/services/controller.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thecodeteam/gocsi/mount"
 )
 
-func (s *StoragePlugin) ControllerGetCapabilities(
+func (s *storagePlugin) ControllerGetCapabilities(
 	ctx context.Context,
 	in *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 
@@ -31,7 +31,7 @@ func (s *StoragePlugin) ControllerGetCapabilities(
 	}, nil
 }
 
-func (s *StoragePlugin) CreateVolume(
+func (s *storagePlugin) CreateVolume(
 	ctx context.Context,
 	in *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 
@@ -40,7 +40,7 @@ func (s *StoragePlugin) CreateVolume(
 		"CreateVolume not valid for NFS"), nil
 }
 
-func (s *StoragePlugin) DeleteVolume(
+func (s *storagePlugin) DeleteVolume(
 	ctx context.Context,
 	in *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 
@@ -49,7 +49,7 @@ func (s *StoragePlugin) DeleteVolume(
 		"DeleteVolume not valid for NFS"), nil
 }
 
-func (s *StoragePlugin) ControllerPublishVolume(
+func (s *storagePlugin) ControllerPublishVolume(
 	ctx context.Context,
 	in *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 
@@ -58,7 +58,7 @@ func (s *StoragePlugin) ControllerPublishVolume(
 		"ControllerPublishVolume not valid for NFS"), nil
 }
 
-func (s *StoragePlugin) ControllerUnpublishVolume(
+func (s *storagePlugin) ControllerUnpublishVolume(
 	ctx context.Context,
 	in *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 
@@ -67,7 +67,7 @@ func (s *StoragePlugin) ControllerUnpublishVolume(
 		"ControllerUnpublishVolume not valid for NFS"), nil
 }
 
-func (s *StoragePlugin) ValidateVolumeCapabilities(
+func (s *storagePlugin) ValidateVolumeCapabilities(
 	ctx context.Context,
 	in *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 
@@ -100,7 +100,7 @@ func (s *StoragePlugin) ValidateVolumeCapabilities(
 	return r, nil
 }
 
-func (s *StoragePlugin) ListVolumes(
+func (s *storagePlugin) ListVolumes(
 	ctx context.Context,
 	in *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 
@@ -151,7 +151,7 @@ func (s *StoragePlugin) ListVolumes(
 	}, nil
 }
 
-func (s *StoragePlugin) GetCapacity(
+func (s *storagePlugin) GetCapacity(
 	ctx context.Context,
 	in *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 

--- a/services/identity.go
+++ b/services/identity.go
@@ -6,7 +6,7 @@ import (
 	"github.com/thecodeteam/gocsi/csi"
 )
 
-func (s *StoragePlugin) GetSupportedVersions(
+func (s *storagePlugin) GetSupportedVersions(
 	ctx context.Context,
 	req *csi.GetSupportedVersionsRequest) (
 	*csi.GetSupportedVersionsResponse, error) {
@@ -20,7 +20,7 @@ func (s *StoragePlugin) GetSupportedVersions(
 	}, nil
 }
 
-func (s *StoragePlugin) GetPluginInfo(
+func (s *storagePlugin) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (
 	*csi.GetPluginInfoResponse, error) {
@@ -28,8 +28,8 @@ func (s *StoragePlugin) GetPluginInfo(
 	return &csi.GetPluginInfoResponse{
 		Reply: &csi.GetPluginInfoResponse_Result_{
 			Result: &csi.GetPluginInfoResponse_Result{
-				Name:          SpName,
-				VendorVersion: spVersion,
+				Name:          Name,
+				VendorVersion: Version,
 				Manifest:      nil,
 			},
 		},

--- a/services/node.go
+++ b/services/node.go
@@ -16,7 +16,7 @@ import (
 	"github.com/thecodeteam/csi-nfs/nfs"
 )
 
-func (s *StoragePlugin) NodePublishVolume(
+func (s *storagePlugin) NodePublishVolume(
 	ctx context.Context,
 	in *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 
@@ -58,7 +58,7 @@ func (s *StoragePlugin) NodePublishVolume(
 	return s.handleMount(host, export, target, mf, ro, am)
 }
 
-func (s *StoragePlugin) NodeUnpublishVolume(
+func (s *storagePlugin) NodeUnpublishVolume(
 	ctx context.Context,
 	in *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 
@@ -132,7 +132,7 @@ func (s *StoragePlugin) NodeUnpublishVolume(
 	}, nil
 }
 
-func (s *StoragePlugin) GetNodeID(
+func (s *storagePlugin) GetNodeID(
 	ctx context.Context,
 	in *csi.GetNodeIDRequest) (*csi.GetNodeIDResponse, error) {
 
@@ -145,7 +145,7 @@ func (s *StoragePlugin) GetNodeID(
 	}, nil
 }
 
-func (s *StoragePlugin) ProbeNode(
+func (s *storagePlugin) ProbeNode(
 	ctx context.Context,
 	in *csi.ProbeNodeRequest) (*csi.ProbeNodeResponse, error) {
 
@@ -162,7 +162,7 @@ func (s *StoragePlugin) ProbeNode(
 	}, nil
 }
 
-func (s *StoragePlugin) NodeGetCapabilities(
+func (s *storagePlugin) NodeGetCapabilities(
 	ctx context.Context,
 	in *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 
@@ -190,7 +190,7 @@ func mkdir(path string) (bool, error) {
 	return false, nil
 }
 
-func (s *StoragePlugin) handleMount(
+func (s *storagePlugin) handleMount(
 	host string,
 	export string,
 	target string,
@@ -349,7 +349,7 @@ func (s *StoragePlugin) handleMount(
 	}, nil
 }
 
-func (s *StoragePlugin) getPrivateMountPoint(src string) string {
+func (s *storagePlugin) getPrivateMountPoint(src string) string {
 	return filepath.Join(s.privDir, src)
 }
 

--- a/services/services.go
+++ b/services/services.go
@@ -3,14 +3,17 @@ package services
 import (
 	"os"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/thecodeteam/gocsi/csi"
 )
 
 const (
 	// SpName holds the name of the Storage Plugin / driver
-	SpName    = "csi-nfs"
-	spVersion = "0.1.0"
+	Name    = "csi-nfs"
+	Version = "0.1.0"
 
+	debugEnvVar    = "X_CSI_NFS_DEBUG"
 	mountDirEnvVar = "X_CSI_NFS_MOUNTDIR"
 	defaultDir     = "/dev/csi-nfs-mounts"
 )
@@ -26,15 +29,30 @@ var (
 	}
 )
 
-// StoragePlugin contains parameters for the plugin
-type StoragePlugin struct {
+// Service is the CSI Network File System (NFS) service provider.
+type Service interface {
+	csi.ControllerServer
+	csi.IdentityServer
+	csi.NodeServer
+}
+
+// storagePlugin contains parameters for the plugin
+type storagePlugin struct {
 	privDir string
 }
 
-// Init initializes the plugin based on environment variables
-func (sp *StoragePlugin) Init() {
-	sp.privDir = defaultDir
+// New returns a new Service
+func New() Service {
+
+	sp := &storagePlugin{
+		privDir: defaultDir,
+	}
 	if md := os.Getenv(mountDirEnvVar); md != "" {
 		sp.privDir = md
 	}
+	log.WithFields(map[string]interface{}{
+		"privDir": sp.privDir,
+	}).Info("created new " + Name + " service")
+
+	return sp
 }


### PR DESCRIPTION
Restructure the code so that a common path is used whether being used a
main binary (main.go) or being vendored (provider). This brings the
project inline with how CSI-VFS is structued.

Also add the plugin.go file so golang plugin builds are possible now.